### PR TITLE
Update toolchain and fix package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /lake-packages/*
 *~
+lakefile.olean

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,7 +6,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Lake
 open Lake DSL
 
-package «lean4-unicode-basic»
+package UnicodeBasic
 
 @[default_target]
 lean_lib UnicodeBasic {

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.0.0
+leanprover/lean4:v4.1.0


### PR DESCRIPTION
Package name is changed to be consistent with its usage in `lean4-parser`, otherwise Lake shows a warning.