### PR TITLE
chore: change FilePath to System.FilePath to adapt to upstream

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -24,7 +24,7 @@ lean_exe testTables
 
 -- Download datafile from the Unicode Character Database (UCD)
 script downloadUCD (args) do
-  let dir : FilePath := "./data"
+  let dir : System.FilePath := "./data"
   let url := "https://www.unicode.org/Public/UCD/latest/ucd/"
   let mut err : ExitCode := 0
   for file in args do


### PR DESCRIPTION
This adapts UnicodeBasic for https://github.com/leanprover/lean4/commit/46f1335b80e074712ad30a2f0c16560059e4aada, which makes the `Lake` module no longer export `FilePath`. This was necessary to fix docgen, and ensure that it only refers to `Lean.Name` instead of e.g. `Lake.Name`.

This should allow a smooth bump to the new release candidate when the time comes.
Discovered when bumping toolchain for https://github.com/leanprover/lnsym