### PR TITLE
Revert patch for leanprover/lean4#13372

### DIFF
--- a/UnicodeBasic/CharacterDatabase.lean
+++ b/UnicodeBasic/CharacterDatabase.lean
@@ -15,10 +15,7 @@ namespace Unicode
 structure UCDStream extends String.Slice where
   /-- `isUnihan` is true if the records are tab separated -/
   isUnihan := false
--- deriving Inhabited -- See https://github.com/leanprover/lean4/issues/13372
-
-instance : Inhabited UCDStream where
-  default := { toSlice := "", isUnihan := false }
+deriving Inhabited
 
 namespace UCDStream
 


### PR DESCRIPTION
This reverts commit 79a6e460771cc4a5d5729366603d63848a6255bd. Fixed 13372 in https://github.com/leanprover/lean4/pull/13395