### PR TITLE
Fix Windows build with winsock headers

### DIFF
--- a/UnicodeCLib/basic.c
+++ b/UnicodeCLib/basic.c
@@ -1,5 +1,10 @@
 #include <lean/lean.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
 #include <arpa/inet.h>
+#endif
 #include "basic.h"
 
 static inline int unicode_script_is_valid(uint32_t c) {

--- a/UnicodeCLib/basic.c
+++ b/UnicodeCLib/basic.c
@@ -1,7 +1,6 @@
 #include <lean/lean.h>
 #ifdef _WIN32
 #include <winsock2.h>
-#include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
This fixes `lake build` on Windows by swapping in Windows socket headers under `_WIN32` and keeping `arpa/inet.h` for Unix